### PR TITLE
Legger inn noen ignores slik at swagger fungerer uten innlogging

### DIFF
--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/DittNavArbeidsgiverApplication.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/DittNavArbeidsgiverApplication.java
@@ -5,7 +5,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@EnableOIDCTokenValidation
+@EnableOIDCTokenValidation(ignore = { 
+        "springfox.documentation.swagger.web.ApiResourceController",
+        "org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController" 
+})
 public class DittNavArbeidsgiverApplication {
     public static void main(String [] args) {
         SpringApplication.run(DittNavArbeidsgiverApplication.class, args);


### PR DESCRIPTION
URL `/ditt-nav-arbeidsgiver-api/swagger-ui.html` fungerte ikke siden den krever innlogging. Disse ignorene ser ut til å fikse det. 
Operasjonene man kaller fra swagger vil fortsatt kreve innlogging. Vi kan vurdere å legge inn støtte for innlogging i swagger slik at dette blir enklere.