### PR TITLE
Cache aad-token m/evict og retry ved feil

### DIFF
--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AadAccessToken.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AadAccessToken.java
@@ -1,4 +1,4 @@
-package no.nav.tag.dittNavArbeidsgiver.utils;
+package no.nav.tag.dittNavArbeidsgiver.services.aad;
 
 import lombok.Data;
 

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AadCacheConfig.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AadCacheConfig.java
@@ -1,0 +1,25 @@
+package no.nav.tag.dittNavArbeidsgiver.services.aad;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+public class AadCacheConfig {
+
+    final static String AAD_CACHE = "aad_cache";
+
+    @Bean
+    public CaffeineCache aadCache() {
+        return new CaffeineCache(AAD_CACHE,
+                Caffeine.newBuilder()
+                    .maximumSize(1)
+                    .expireAfterWrite(59, TimeUnit.MINUTES)
+                    .recordStats()
+                    .build());
+    }
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AccesstokenClient.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/aad/AccesstokenClient.java
@@ -1,10 +1,14 @@
-package no.nav.tag.dittNavArbeidsgiver.utils;
+package no.nav.tag.dittNavArbeidsgiver.services.aad;
 
 
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import static no.nav.tag.dittNavArbeidsgiver.services.aad.AadCacheConfig.AAD_CACHE;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -14,26 +18,16 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Component
+@Setter
 @ConfigurationProperties("aad")
 public class AccesstokenClient {
 
-    public void setAadAccessTokenURL(String aadAccessTokenURL) {
-        this.aadAccessTokenURL = aadAccessTokenURL;
-
-    }
-
     private String aadAccessTokenURL;
-    @Setter
     private String clientid;
-    @Setter
     private String azureClientSecret;
-    @Setter
     private String scope;
-    @Autowired
-    public AccesstokenClient( ){
 
-    }
-
+    @Cacheable(AAD_CACHE)
     public AadAccessToken hentAccessToken() {
         RestTemplate template = new RestTemplate();
         HttpEntity<MultiValueMap<String, String>> entity = getRequestEntity();
@@ -59,4 +53,9 @@ public class AccesstokenClient {
 
         return new HttpEntity<>(map, headers);
     }
+    
+    @CacheEvict(AAD_CACHE)
+    public void evict() {
+    }
+
 }

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoService.java
@@ -3,6 +3,7 @@ package no.nav.tag.dittNavArbeidsgiver.services.digisyfo;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.security.oidc.OIDCConstants;
 import no.nav.tag.dittNavArbeidsgiver.models.DigisyfoNarmesteLederRespons;
+import no.nav.tag.dittNavArbeidsgiver.services.aad.AadAccessToken;
 import no.nav.tag.dittNavArbeidsgiver.services.aad.AccesstokenClient;
 import no.nav.tag.dittNavArbeidsgiver.services.aktor.AktorClient;
 
@@ -43,6 +44,12 @@ public class DigisyfoService {
         try {
             return hentNarmesteLederFraDigiSyfo(getRequestEntity(), url);
         } catch (RestClientException e1) {
+            AadAccessToken token = accesstokenClient.hentAccessToken();
+            log.warn("Kall mot digisyfo feilet - kan skyldes utløpt token. expires_in: {}, ext_expires_in: {}, expires_on: {}", 
+                    token.getExpires_in(),
+                    token.getExt_expires_in(), 
+                    token.getExpires_on(), 
+                    e1);
             accesstokenClient.evict();
             try {
                 return hentNarmesteLederFraDigiSyfo(getRequestEntity(), url);

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoService.java
@@ -3,8 +3,9 @@ package no.nav.tag.dittNavArbeidsgiver.services.digisyfo;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.security.oidc.OIDCConstants;
 import no.nav.tag.dittNavArbeidsgiver.models.DigisyfoNarmesteLederRespons;
+import no.nav.tag.dittNavArbeidsgiver.services.aad.AccesstokenClient;
 import no.nav.tag.dittNavArbeidsgiver.services.aktor.AktorClient;
-import no.nav.tag.dittNavArbeidsgiver.utils.AccesstokenClient;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.*;
@@ -23,8 +24,9 @@ public class DigisyfoService {
     private final AccesstokenClient accesstokenClient;
     private final AktorClient aktorClient;
     private final RestTemplate restTemplate;
+
     @Value("${digisyfo.digisyfoUrl}")
-    private String digisyfoUrl;
+    String digisyfoUrl;
     @Value("${digisyfo.sykemeldteURL}")
     private String sykemeldteURL;
     @Value("${digisyfo.syfooppgaveurl}")
@@ -37,25 +39,33 @@ public class DigisyfoService {
     }
 
     public DigisyfoNarmesteLederRespons getNarmesteledere(String fnr) {
-            /*
-            TODO: lagre accestoken fra AD (med en session?) så man slipper å spørre AD hver gang man skal sjekke nærmeste leder tilgang
-             */
-        HttpEntity <String> entity = getRequestEntity();
-        String url = UriComponentsBuilder.fromHttpUrl(digisyfoUrl+ aktorClient.getAktorId(fnr))
-                .toUriString();
+        String url = UriComponentsBuilder.fromHttpUrl(digisyfoUrl+ aktorClient.getAktorId(fnr)).toUriString();
         try {
-            ResponseEntity<DigisyfoNarmesteLederRespons> respons = restTemplate.exchange(url,
-                    HttpMethod.GET, entity, DigisyfoNarmesteLederRespons.class);
-            if (respons.getStatusCode() != HttpStatus.OK) {
-                String message = "Kall mot digisyfo feiler med HTTP-" + respons.getStatusCode();
-                log.error(message);
-                throw new RuntimeException(message);
+            return hentNarmesteLederFraDigiSyfo(getRequestEntity(), url);
+        } catch (RestClientException e1) {
+            accesstokenClient.evict();
+            try {
+                return hentNarmesteLederFraDigiSyfo(getRequestEntity(), url);
+            } catch (RestClientException e2) {
+                log.error(" Digisyfo Exception: ", e2);
+                throw new RuntimeException(" Digisyfo Exception: " + e2);
             }
-            return respons.getBody();
-        } catch (RestClientException exception) {
-            log.error(" Digisyfo Exception: ", exception);
-            throw new RuntimeException(" Digisyfo Exception: " + exception);
         }
+    }
+
+    private DigisyfoNarmesteLederRespons hentNarmesteLederFraDigiSyfo(HttpEntity<String> entity, String url) {
+        ResponseEntity<DigisyfoNarmesteLederRespons> respons = restTemplate.exchange(
+                url,
+                HttpMethod.GET, 
+                entity, 
+                DigisyfoNarmesteLederRespons.class);
+        
+        if (respons.getStatusCode() != HttpStatus.OK) {
+            String message = "Kall mot digisyfo feiler med HTTP-" + respons.getStatusCode();
+            log.error(message);
+            throw new RuntimeException(message);
+        }
+        return respons.getBody();
     }
 
     private HttpEntity <String> getRequestEntity() {

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/sts/STSClient.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/sts/STSClient.java
@@ -59,6 +59,4 @@ public class STSClient {
     public void evict() {
     }
 
-
-
 }

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/aktor/AktorClientTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/aktor/AktorClientTest.java
@@ -2,8 +2,6 @@ package no.nav.tag.dittNavArbeidsgiver.services.aktor;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoServiceTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoServiceTest.java
@@ -66,7 +66,7 @@ public class DigisyfoServiceTest {
             .thenThrow(RestClientException.class).thenReturn(ResponseEntity.ok(respons));
         assertThat(digisyfoService.getNarmesteledere(FNR)).isSameAs(respons);
 
-        verify(accesstokenClient, times(2)).hentAccessToken();
+        verify(accesstokenClient, times(3)).hentAccessToken();
         verify(accesstokenClient).evict();
         verify(restTemplate, times(2)).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
 
@@ -81,7 +81,7 @@ public class DigisyfoServiceTest {
             digisyfoService.getNarmesteledere(FNR);
         } catch (Exception e) {
             //Må catche exception her for å kunne gjøre verifiseringer
-            verify(accesstokenClient, times(2)).hentAccessToken();
+            verify(accesstokenClient, times(3)).hentAccessToken();
             verify(accesstokenClient).evict();
             verify(restTemplate, times(2)).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
             throw(e);

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoServiceTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/digisyfo/DigisyfoServiceTest.java
@@ -1,0 +1,109 @@
+package no.nav.tag.dittNavArbeidsgiver.services.digisyfo;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import no.nav.tag.dittNavArbeidsgiver.models.DigisyfoNarmesteLederRespons;
+import no.nav.tag.dittNavArbeidsgiver.services.aad.AadAccessToken;
+import no.nav.tag.dittNavArbeidsgiver.services.aad.AccesstokenClient;
+import no.nav.tag.dittNavArbeidsgiver.services.aktor.AktorClient;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DigisyfoServiceTest {
+
+    private static final String AKTOERID = "aktoerid";
+    private static final String FNR = "123";
+    private static final String SYFO_URL = "http://test";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private AktorClient aktorClient;
+
+    @Mock
+    private AccesstokenClient accesstokenClient;
+
+    @InjectMocks
+    private DigisyfoService digisyfoService;
+
+    @Before
+    public void setUp() {
+        digisyfoService.digisyfoUrl = SYFO_URL;
+        when(aktorClient.getAktorId(FNR)).thenReturn(AKTOERID);
+        when(accesstokenClient.hentAccessToken()).thenReturn(new AadAccessToken());
+    }
+
+    @Test
+    public void getNarmesteledere_skal_hente_aktørid_og_accessToken_og_returnere_svar_fra_Digisyfo() {
+        DigisyfoNarmesteLederRespons respons = new DigisyfoNarmesteLederRespons();
+        when(restTemplate.exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class)))
+            .thenReturn(ResponseEntity.ok(respons));
+        assertThat(digisyfoService.getNarmesteledere(FNR)).isSameAs(respons);
+
+        verify(aktorClient).getAktorId(FNR);
+        verify(accesstokenClient).hentAccessToken();
+        verify(restTemplate).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
+        verifyNoMoreInteractions(aktorClient, accesstokenClient, restTemplate);
+    }
+
+    @Test
+    public void getNarmesteledere_skal_evicte_token_og_prøve_igjen_dersom_syfo_feiler() {
+        DigisyfoNarmesteLederRespons respons = new DigisyfoNarmesteLederRespons();
+        when(restTemplate.exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class)))
+            .thenThrow(RestClientException.class).thenReturn(ResponseEntity.ok(respons));
+        assertThat(digisyfoService.getNarmesteledere(FNR)).isSameAs(respons);
+
+        verify(accesstokenClient, times(2)).hentAccessToken();
+        verify(accesstokenClient).evict();
+        verify(restTemplate, times(2)).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
+
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getNarmesteledere_skal_kaste_exception_dersom_syfo_feiler_to_ganger() {
+        when(restTemplate.exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class)))
+            .thenThrow(RestClientException.class);
+
+        try {
+            digisyfoService.getNarmesteledere(FNR);
+        } catch (Exception e) {
+            //Må catche exception her for å kunne gjøre verifiseringer
+            verify(accesstokenClient, times(2)).hentAccessToken();
+            verify(accesstokenClient).evict();
+            verify(restTemplate, times(2)).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
+            throw(e);
+        }
+
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void getNarmesteledere_skal_kaste_exception_dersom_syfo_ikke_svarer_http_ok() {
+        when(restTemplate.exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class)))
+            .thenReturn(ResponseEntity.badRequest().build());
+
+        try {
+            digisyfoService.getNarmesteledere(FNR);
+        } catch (Exception e) {
+            //Må catche exception her for å kunne gjøre verifiseringer
+            verify(aktorClient).getAktorId(FNR);
+            verify(accesstokenClient).hentAccessToken();
+            verify(restTemplate).exchange(eq(SYFO_URL + AKTOERID), eq(HttpMethod.GET), any(HttpEntity.class), eq(DigisyfoNarmesteLederRespons.class));
+            verifyNoMoreInteractions(aktorClient, accesstokenClient, restTemplate);
+            throw(e);
+        }
+
+    }
+}


### PR DESCRIPTION
Cacher tokenet i 59 minutter på samme måte som sts-token.
Dersom syfo-tjenesten feiler, henter vi nytt token og forsøker på nytt.

Flyttet også `AccesstokenClient` til en egen pakke og skrev noen tester