### PR TITLE
Tag 862 mange bedrifter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/mockserver/MockServer.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/mockserver/MockServer.java
@@ -16,12 +16,18 @@ import org.springframework.stereotype.Component;
 import java.net.URL;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Profile({"dev"})
 @Slf4j
 @Component
 public class MockServer {
+
+    public static final String SERVICE_EDITION = "1";
+    public static final String SERVICE_CODE = "4936";
+    public static final String FNR_MED_SKJEMATILGANG = "01065500791";
+    public static final String FNR_MED_ORGANISASJONER = "00000000000";
 
     @SneakyThrows
     @Autowired
@@ -61,7 +67,7 @@ public class MockServer {
 
     private static void mockOrganisasjoner(WireMockServer server, String altinnPath) {
         server.stubFor(WireMock.get(WireMock.urlPathEqualTo(altinnPath + "reportees/"))
-                .withQueryParam("subject", equalTo("00000000000"))
+                .withQueryParam("subject", equalTo(FNR_MED_ORGANISASJONER))
                 .willReturn(WireMock.aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(hentStringFraFil("organisasjoner.json"))
@@ -69,9 +75,9 @@ public class MockServer {
     }
     private static void mocktilgangTilSkjemForBedrift(WireMockServer server, String altinnPath) {
         server.stubFor(WireMock.get(WireMock.urlPathEqualTo(altinnPath + "reportees/"))
-                .withQueryParam("subject", equalTo("01065500791"))
-                .withQueryParam("serviceCode", equalTo("4936"))
-                .withQueryParam("serviceEdition", equalTo("1"))
+                .withQueryParam("subject", equalTo(FNR_MED_SKJEMATILGANG))
+                .withQueryParam("serviceCode", equalTo(SERVICE_CODE))
+                .withQueryParam("serviceEdition", equalTo(SERVICE_EDITION))
                 .willReturn(WireMock.aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(hentStringFraFil("rettigheterTilSkjema.json"))
@@ -80,12 +86,11 @@ public class MockServer {
 
     private static void mockInvalidSSN(WireMockServer server, String altinnPath) {
         server.stubFor(WireMock.get(WireMock.urlPathEqualTo(altinnPath + "reportees/"))
-                .withQueryParam("subject", WireMock.notMatching("00000000000|01065500791"))
+                .withQueryParam("subject", notMatching(FNR_MED_ORGANISASJONER + "|" + FNR_MED_SKJEMATILGANG))
                 .willReturn(WireMock.aResponse().withStatusMessage("Invalid socialSecurityNumber").withStatus(400)
                         .withHeader("Content-Type", "application/octet-stream")
                 ));
     }
-
 
     private static void mockForPath(WireMockServer server, String path, String responseFile){
         server.stubFor(WireMock.any(WireMock.urlPathMatching(path + ".*"))

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Organisasjon.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Organisasjon.java
@@ -3,10 +3,13 @@ package no.nav.tag.dittNavArbeidsgiver.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
 import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@Builder
 public class Organisasjon {
     @JsonProperty("Name")
     private String name;

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Organisasjon.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Organisasjon.java
@@ -4,12 +4,16 @@ package no.nav.tag.dittNavArbeidsgiver.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Organisasjon {
     @JsonProperty("Name")
     private String name;

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Role.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/Role.java
@@ -2,10 +2,13 @@ package no.nav.tag.dittNavArbeidsgiver.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
 import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@Builder
 public class Role {
     @JsonProperty("RoleDefinitionId")
     private int roleId;

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
@@ -23,7 +23,8 @@ import static no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnCacheConfig.A
 @Component
 public class AltinnService {
 
-    private static final int ALTINN_PAGE_SIZE = 500;
+    private static final int ALTINN_ORG_PAGE_SIZE = 500;
+    private static final int ALTINN_ROLE_PAGE_SIZE = 50;
 
     private final AltinnConfig altinnConfig;
 
@@ -41,14 +42,14 @@ public class AltinnService {
                 + "&$filter=(Type+eq+'Bedrift'+or+Type+eq+'Business'+or+Type+eq+'Enterprise'+or+Type+eq+'Foretak')+and+Status+eq+'Active'";
         String url = altinnConfig.getAltinnurl() + "reportees/?ForceEIAuthentication" + query;
         log.info("Henter organisasjoner fra Altinn");
-        return getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},url, ALTINN_PAGE_SIZE);
+        return getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},url, ALTINN_ORG_PAGE_SIZE);
     }
 
     public List<Role> hentRoller(String fnr, String orgnr) {
         String query = "&subject=" + fnr + "&reportee=" + orgnr;
         String url = altinnConfig.getAltinnurl() + "authorization/roles?ForceEIAuthentication" + query;
         log.info("Henter roller fra Altinn");
-        return getFromAltinn(new ParameterizedTypeReference<List<Role>>() {},url, ALTINN_PAGE_SIZE);
+        return getFromAltinn(new ParameterizedTypeReference<List<Role>>() {},url, ALTINN_ROLE_PAGE_SIZE);
     }
 
     @Cacheable(ALTINN_TJENESTE_CACHE)
@@ -58,7 +59,7 @@ public class AltinnService {
                 + "&serviceEdition=" + serviceEdition; 
         String url = altinnConfig.getAltinnurl() + "reportees/?ForceEIAuthentication" + query;
         log.info("Henter rettigheter fra Altinn");
-        return getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},url, ALTINN_PAGE_SIZE);
+        return getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},url, ALTINN_ORG_PAGE_SIZE);
     }
 
     private HttpEntity<String>  getHeaderEntity() {

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
@@ -69,7 +69,7 @@ public class AltinnService {
         return new HttpEntity<>(headers);
     }
 
-    private <T> List<T> getFromAltinn(ParameterizedTypeReference<List<T>> typeReference, String url, int pageSize) {
+    <T> List<T> getFromAltinn(ParameterizedTypeReference<List<T>> typeReference, String url, int pageSize) {
 
         Set<T> response = new HashSet<T>();
         HttpEntity<String> headers = getHeaderEntity();
@@ -79,7 +79,8 @@ public class AltinnService {
             pageNumber++;
             try {
                 String urlWithPagesizeAndOffset = url + "&$top=" + pageSize + "&$skip=" + ((pageNumber-1) * pageSize);
-                List<T> currentResponseList = restTemplate.exchange(urlWithPagesizeAndOffset, HttpMethod.GET, headers, typeReference).getBody();
+                ResponseEntity<List<T>> exchange = restTemplate.exchange(urlWithPagesizeAndOffset, HttpMethod.GET, headers, typeReference);
+                List<T> currentResponseList = exchange.getBody();
                 response.addAll(currentResponseList);
                 hasMore = currentResponseList.size() >= pageSize;
             } catch (RestClientException exception) {

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
@@ -12,7 +12,9 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnCacheConfig.ALTINN_CACHE;
 import static no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnCacheConfig.ALTINN_TJENESTE_CACHE;
@@ -68,7 +70,7 @@ public class AltinnService {
 
     private <T> List<T> getFromAltinn(ParameterizedTypeReference<List<T>> typeReference, String url, int pageSize) {
 
-        List<T> response = new ArrayList<T>();
+        Set<T> response = new HashSet<T>();
         HttpEntity<String> headers = getHeaderEntity();
         int pageNumber = 0;
         boolean hasMore = true;
@@ -84,7 +86,7 @@ public class AltinnService {
                 throw new AltinnException("Feil fra Altinn", exception);
             }
         }
-        return response;
+        return new ArrayList<T>(response);
     }
 
 }

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceIntegrationTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceIntegrationTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 @SpringBootTest
 @ActiveProfiles("dev")
 @TestPropertySource(properties = {"mock.port=8082"})
-public class AltinnServiceTest {
+public class AltinnServiceIntegrationTest {
 
     @Autowired
     private AltinnService altinnService;

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
@@ -1,0 +1,34 @@
+package no.nav.tag.dittNavArbeidsgiver.services.altinn;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
+
+public class AltinnServiceTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void hentOrganisasjoner__skal_kalle_altinn_flere_ganger_ved_stor_respons() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class)))
+            .thenReturn(ResponseEntity.ok(asList(new Organisasjon())))
+            .thenReturn(ResponseEntity.ok(emptyList()));
+        AltinnService altinnService = new AltinnService(new AltinnConfig(), restTemplate);
+        altinnService.getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},"http://blabla", 1);
+        verify(restTemplate, times(1)).exchange(endsWith("&$top=1&$skip=0"), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
+        verify(restTemplate, times(1)).exchange(endsWith("&$top=1&$skip=1"), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
+        verifyNoMoreInteractions(restTemplate);
+    }
+    
+}

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
@@ -1,6 +1,8 @@
 package no.nav.tag.dittNavArbeidsgiver.services.altinn;
 
 import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
+import no.nav.tag.dittNavArbeidsgiver.models.Role;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +10,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.FNR_MED_ORGANISASJONER;
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.FNR_MED_SKJEMATILGANG;
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.SERVICE_CODE;
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.SERVICE_EDITION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -23,23 +31,25 @@ public class AltinnServiceTest {
 
     @Test
     public void hentOrganisasjoner__skal_fungere_med_gyldig_fnr() {
-        altinnService.hentOrganisasjoner("00000000000");
+        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(FNR_MED_ORGANISASJONER);
+        assertThat(organisasjoner).contains(Organisasjon.builder().name("SKOTSELV OG HJELSET").type("Enterprise").organizationNumber("910720120").organizationForm("AS").status("Active").build());
     }
 
     @Test(expected = AltinnException.class)
     public void hentOrganisasjoner__skal_kaste_altinn_exception_hvis_ugyldig_fnr() {
-         altinnService.hentOrganisasjoner("04010100655");
+         altinnService.hentOrganisasjoner("11111111111");
     }
 
     @Test
     public void hentRoller__skal_fungere_med_gyldig_fnr_og_orgno() {
-        altinnService.hentRoller("00000000000","000000000");
+        List<Role> roller = altinnService.hentRoller(FNR_MED_ORGANISASJONER,"000000000");
+        assertThat(roller).contains(Role.builder().roleId(272).roleType("Altinn").roleName("Primary industry and foodstuff").roleDescription("Import, processing, production and/or sales of primary products and other foodstuff").build());
     }
+
     @Test
     public void henttilgangTilSkjemForBedrift() {
-        List<Organisasjon> respons= altinnService.hentOrganisasjonerBasertPaRettigheter("01065500791", "4936", "1");
-        System.out.println(respons);
-
+        List<Organisasjon> organisasjoner= altinnService.hentOrganisasjonerBasertPaRettigheter(FNR_MED_SKJEMATILGANG, SERVICE_CODE, SERVICE_EDITION);
+        assertThat(organisasjoner).contains(Organisasjon.builder().name("JØA OG SEL").type("Business").parentOrganizationNumber("910020102").organizationNumber("910098896").organizationForm("BEDR").status("Active").build());
     }
 
 }


### PR DESCRIPTION
Støtte for paginering ved henting av lister fra AltInn-APIet.
Api-et har støtte for at klienten både kan angi maks antall respons-elementer i listen, og sette en offset/skip, for å kunne paginere gjennom store resultatsett ved flere spørringer.
Til nå har vi kun brukt parameter for å angi maks-antall. Denne har vi angitt til 500. Dermed vil brukere som har mer enn 500 bedrifter ikke få frem alle. 
Denne PR-en fikser dette problemet, da den vil gjøre nye spørringer helt til API-et returnerer mindre enn maks antall elementer.
Jeg har gjort denne funksjonaliteten generell, så den fungerer både på organisasjoner og roller. Merk at rolle-oppslaget til AltInn har en maks-grense på 50 elementer, mens oppslaget på organisasjoner har maks 500.