### PR TITLE
Bruke Altinn-rettigheter-proxy-klient lib for å kalle Altinn proxy fo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <oidc-support.version>0.2.18</oidc-support.version>
+        <altinn-rettigheter-proxy-klient.version>0.1.1</altinn-rettigheter-proxy-klient.version>
     </properties>
 
     <dependencies>
@@ -70,6 +71,11 @@
             <groupId>no.nav.security</groupId>
             <artifactId>oidc-test-support</artifactId>
             <version>${oidc-support.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.arbeidsgiver</groupId>
+            <artifactId>altinn-rettigheter-proxy-klient</artifactId>
+            <version>${altinn-rettigheter-proxy-klient.version}</version>
         </dependency>
 
         <!-- Swagger -->

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnConfig.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnConfig.java
@@ -12,4 +12,5 @@ public class AltinnConfig {
     private String altinnurl;
     private String APIGwHeader;
     private String proxyUrl;
+    private String proxyFallbackUrl;
 }

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnService.java
@@ -2,6 +2,12 @@ package no.nav.tag.dittNavArbeidsgiver.services.altinn;
 
 import lombok.extern.slf4j.Slf4j;
 import no.finn.unleash.Unleash;
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient;
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig;
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.ProxyConfig;
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee;
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.Subject;
+import no.nav.security.oidc.context.TokenContext;
 import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
 import no.nav.tag.dittNavArbeidsgiver.models.Role;
 import no.nav.tag.dittNavArbeidsgiver.utils.TokenUtils;
@@ -16,10 +22,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import static no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnCacheConfig.ALTINN_CACHE;
 import static no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnCacheConfig.ALTINN_TJENESTE_CACHE;
@@ -35,6 +40,8 @@ public class AltinnService {
     private final HttpEntity<HttpHeaders> headerEntity;
     private final String altinnUrl;
     private final String altinnProxyUrl;
+    private final String altinnProxyFallbackUrl;
+    private final AltinnrettigheterProxyKlient klient;
     private final TokenUtils tokenUtils;
     private final Unleash unleash;
 
@@ -43,6 +50,7 @@ public class AltinnService {
         this.restTemplate = restTemplate;
         this.altinnUrl = altinnConfig.getAltinnurl();
         this.altinnProxyUrl = altinnConfig.getProxyUrl();
+        this.altinnProxyFallbackUrl = altinnConfig.getProxyFallbackUrl();
         this.tokenUtils = tokenUtils;
         this.unleash = unleash;
 
@@ -50,13 +58,39 @@ public class AltinnService {
         headers.set("X-NAV-APIKEY", altinnConfig.getAPIGwHeader());
         headers.set("APIKEY", altinnConfig.getAltinnHeader());
         this.headerEntity = new HttpEntity<>(headers);
+
+        AltinnrettigheterProxyKlientConfig proxyKlientConfig = new AltinnrettigheterProxyKlientConfig(
+                new ProxyConfig("ditt-nav-arbeidsgiver-api", altinnProxyUrl),
+                new no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig(
+                        altinnProxyFallbackUrl,
+                        altinnConfig.getAltinnHeader(),
+                        altinnConfig.getAPIGwHeader()
+                )
+        );
+        this.klient = new AltinnrettigheterProxyKlient(proxyKlientConfig);
     }
 
     @Cacheable(ALTINN_CACHE)
     public List<Organisasjon> hentOrganisasjoner(String fnr) {
-        String query = "&$filter=Type+ne+'Person'+and+Status+eq+'Active'";
-        log.info("Henter organisasjoner fra Altinn");
-        return hentReporteesFraAltinn(query, fnr);
+        String filterParamVerdi = "Type+ne+'Person'+and+Status+eq+'Active'";
+
+        if (unleash.isEnabled("arbeidsgiver.ditt-nav-arbeidsgiver-api.bruk-altinn-proxy")) {
+            Map<String, String> parametre = new ConcurrentHashMap<>();
+            parametre.put("$filter", filterParamVerdi);
+            log.info("Henter organisasjoner fra Altinn via proxy");
+
+            return getReporteesFromAltinnViaProxy(
+                    tokenUtils.getSelvbetjeningTokenContext(),
+                    new Subject(fnr),
+                    parametre,
+                    altinnProxyUrl,
+                    ALTINN_ORG_PAGE_SIZE
+            );
+        } else {
+            String query = String.format("&$filter=%s", filterParamVerdi);
+            log.info("Henter organisasjoner fra Altinn");
+            return hentReporteesFraAltinn(query, fnr);
+        }
     }
 
     public List<Role> hentRoller(String fnr, String orgnr) {
@@ -68,28 +102,65 @@ public class AltinnService {
 
     @Cacheable(ALTINN_TJENESTE_CACHE)
     public List<Organisasjon> hentOrganisasjonerBasertPaRettigheter(String fnr, String serviceKode, String serviceEdition) {
-        String query = "&serviceCode=" + serviceKode
-                + "&serviceEdition=" + serviceEdition;
-        log.info("Henter rettigheter fra Altinn");
-        return hentReporteesFraAltinn(query, fnr);
+        if (unleash.isEnabled("arbeidsgiver.ditt-nav-arbeidsgiver-api.bruk-altinn-proxy")) {
+            Map<String, String> parametre = new ConcurrentHashMap<>();
+            parametre.put("serviceCode", serviceKode);
+            parametre.put("serviceEdition", serviceEdition);
+            log.info("Henter rettigheter fra Altinn via proxy");
+
+            return getReporteesFromAltinnViaProxy(
+                    tokenUtils.getSelvbetjeningTokenContext(),
+                    new Subject(fnr),
+                    parametre,
+                    altinnProxyUrl,
+                    ALTINN_ORG_PAGE_SIZE
+            );
+        } else {
+            String query = "&serviceCode=" + serviceKode
+                    + "&serviceEdition=" + serviceEdition;
+            log.info("Henter rettigheter fra Altinn");
+            return hentReporteesFraAltinn(query, fnr);
+        }
     }
+
 
     private List<Organisasjon> hentReporteesFraAltinn(String query, String fnr) {
         String baseUrl;
         HttpEntity<HttpHeaders> headers;
 
-        if (unleash.isEnabled("arbeidsgiver.ditt-nav-arbeidsgiver-api.bruk-altinn-proxy")) {
-            baseUrl = altinnProxyUrl;
-            headers = getAuthHeadersForInnloggetBruker();
-        } else {
-            baseUrl = altinnUrl;
-            headers = headerEntity;
-            query += "&subject=" + fnr;
-        }
-
+        baseUrl = altinnUrl;
+        headers = headerEntity;
+        query += "&subject=" + fnr;
         String url = baseUrl + "reportees/?ForceEIAuthentication" + query;
 
         return getFromAltinn(new ParameterizedTypeReference<>() {}, url, ALTINN_ORG_PAGE_SIZE, headers);
+    }
+
+    List<Organisasjon> getReporteesFromAltinnViaProxy(
+            TokenContext tokenContext,
+            Subject subject,
+            Map<String, String> parametre,
+            String url,
+            int pageSize
+    ) {
+        Set<Organisasjon> response = new HashSet<>();
+        int pageNumber = 0;
+        boolean hasMore = true;
+
+        while (hasMore) {
+            pageNumber++;
+            try {
+                parametre.put("$top", String.valueOf(pageSize));
+                parametre.put("$skip", String.valueOf(((pageNumber - 1) * pageSize)));
+                List<Organisasjon> collection = mapTo(klient.hentOrganisasjoner(tokenContext, subject, parametre));
+                response.addAll(collection);
+                hasMore = collection.size() >= pageSize;
+            } catch (RestClientException exception) {
+                log.error("Feil fra Altinn-proxy med spørring: " + url + " Exception: " + exception.getMessage());
+                throw new AltinnException("Feil fra Altinn", exception);
+            }
+        }
+        return new ArrayList<>(response);
     }
 
     <T> List<T> getFromAltinn(ParameterizedTypeReference<List<T>> typeReference, String url, int pageSize, HttpEntity<HttpHeaders> headers) {
@@ -113,10 +184,18 @@ public class AltinnService {
         return new ArrayList<T>(response);
     }
 
-    private HttpEntity<HttpHeaders> getAuthHeadersForInnloggetBruker() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(tokenUtils.getTokenForInnloggetBruker());
-        return new HttpEntity<>(headers);
-    }
+    private List<Organisasjon> mapTo(List<AltinnReportee> altinnReportees) {
+        return altinnReportees.stream().map(org -> {
+                    Organisasjon altinnOrganisasjon = new Organisasjon();
+                    altinnOrganisasjon.setName(org.getName());
+                    altinnOrganisasjon.setType(org.getType());
+                    altinnOrganisasjon.setParentOrganizationNumber(org.getParentOrganizationNumber());
+                    altinnOrganisasjon.setOrganizationNumber(org.getOrganizationNumber());
+                    altinnOrganisasjon.setOrganizationForm(org.getOrganizationForm());
+                    altinnOrganisasjon.setStatus(org.getStatus());
 
+                    return altinnOrganisasjon;
+                }
+        ).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/utils/TokenUtils.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/utils/TokenUtils.java
@@ -1,6 +1,7 @@
 package no.nav.tag.dittNavArbeidsgiver.utils;
 
 import no.nav.security.oidc.context.OIDCRequestContextHolder;
+import no.nav.security.oidc.context.TokenContext;
 import org.springframework.stereotype.Component;
 
 import static no.nav.tag.dittNavArbeidsgiver.utils.FnrExtractor.ISSUER_SELVBETJENING;
@@ -16,4 +17,9 @@ public class TokenUtils {
     public String getTokenForInnloggetBruker() {
         return requestContextHolder.getOIDCValidationContext().getToken(ISSUER_SELVBETJENING).getIdToken();
     }
+
+    public TokenContext getSelvbetjeningTokenContext() {
+        return requestContextHolder.getOIDCValidationContext().getToken(ISSUER_SELVBETJENING);
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,8 @@ altinn:
   altinnUrl: "http://localhost:${mock.port}/altinn/"
   altinnHeader: "test"
   APIGwHeader: "test"
-  proxyUrl: "http://localhost:${mock.port}/altinn/"
+  proxyUrl: http://localhost:${mock.port}/altinn-rettigheter-proxy
+  proxyFallbackUrl: http://localhost:${mock.port}/altinn
 
 pdl:
   pdlUrl: "http://localhost:${mock.port}/graphql"
@@ -105,7 +106,9 @@ altinn:
   altinnUrl: "https://api-gw-q1.adeo.no/ekstern/altinn/api/serviceowner/"
   altinnHeader: ${ALTINN_HEADER}
   APIGwHeader: ${APIGW_HEADER}
-  proxyUrl: https://arbeidsgiver.nais.preprod.local/altinn-rettigheter-proxy/ekstern/altinn/api/serviceowner/
+  proxyUrl: https://arbeidsgiver.nais.preprod.local/altinn-rettigheter-proxy
+  proxyFallbackUrl: https://api-gw-q1.adeo.no
+
 
 unleash:
   url: https://unleash.nais.adeo.no/api
@@ -153,7 +156,8 @@ altinn:
   altinnUrl: "https://api-gw.adeo.no/ekstern/altinn/api/serviceowner/"
   altinnHeader: ${ALTINN_HEADER}
   APIGwHeader: ${APIGW_HEADER}
-  proxyUrl: https://arbeidsgiver.nais.adeo.no/altinn-rettigheter-proxy/ekstern/altinn/api/serviceowner/
+  proxyUrl: https://arbeidsgiver.nais.adeo.no/altinn-rettigheter-proxy
+  proxyFallbackUrl: https://api-gw.adeo.no
 
 unleash:
   url: https://unleash.nais.adeo.no/api

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceIntegrationTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceIntegrationTest.java
@@ -3,7 +3,6 @@ package no.nav.tag.dittNavArbeidsgiver.services.altinn;
 import no.finn.unleash.Unleash;
 import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
 import no.nav.tag.dittNavArbeidsgiver.models.Role;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,13 +12,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.FNR_MED_ORGANISASJONER;
-import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.FNR_MED_SKJEMATILGANG;
-import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.SERVICE_CODE;
-import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.SERVICE_EDITION;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.List;
+
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RunWith(SpringRunner.class)
@@ -37,7 +33,15 @@ public class AltinnServiceIntegrationTest {
     @Test
     public void hentOrganisasjoner__skal_fungere_med_gyldig_fnr() {
         List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(FNR_MED_ORGANISASJONER);
-        assertThat(organisasjoner).contains(Organisasjon.builder().name("SKOTSELV OG HJELSET").type("Enterprise").organizationNumber("910720120").organizationForm("AS").status("Active").build());
+        assertThat(organisasjoner).contains(
+                Organisasjon.builder()
+                        .name("SKOTSELV OG HJELSET")
+                        .type("Enterprise")
+                        .organizationNumber("910720120")
+                        .organizationForm("AS")
+                        .status("Active")
+                        .build()
+        );
     }
 
     @Test(expected = AltinnException.class)

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceMedAltinnProxyIntegrationTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceMedAltinnProxyIntegrationTest.java
@@ -1,0 +1,92 @@
+package no.nav.tag.dittNavArbeidsgiver.services.altinn;
+
+import no.finn.unleash.Unleash;
+import no.nav.security.oidc.context.TokenContext;
+import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
+import no.nav.tag.dittNavArbeidsgiver.utils.TokenUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static no.nav.tag.dittNavArbeidsgiver.mockserver.MockServer.*;
+import static no.nav.tag.dittNavArbeidsgiver.utils.FnrExtractor.ISSUER_SELVBETJENING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {"mock.port=8086"})
+public class AltinnServiceMedAltinnProxyIntegrationTest {
+
+    @MockBean
+    private Unleash unleash;
+
+    @MockBean
+    private TokenUtils tokenUtils;
+
+
+    @Autowired
+    private AltinnService altinnService;
+
+    @Before
+    public void setUp() {
+        when(unleash.isEnabled("arbeidsgiver.ditt-nav-arbeidsgiver-api.bruk-altinn-proxy")).thenReturn(true);
+    }
+
+    @Test
+    public void hentOrganisasjoner__skal_fungere_med_gyldig_fnr() {
+        setTokenContext(FNR_MED_ORGANISASJONER);
+
+        List<Organisasjon> organisasjoner = altinnService.hentOrganisasjoner(FNR_MED_ORGANISASJONER);
+        assertThat(organisasjoner).contains(
+                Organisasjon.builder()
+                        .name("SKOTSELV OG HJELSET")
+                        .type("Enterprise")
+                        .organizationNumber("910720120")
+                        .organizationForm("AS")
+                        .status("Active")
+                        .build()
+        );
+    }
+
+    @Test
+    public void henttilgangTilSkjemForBedrift() {
+        setTokenContext(FNR_MED_SKJEMATILGANG);
+
+        List<Organisasjon> organisasjoner= altinnService.hentOrganisasjonerBasertPaRettigheter(
+                FNR_MED_SKJEMATILGANG,
+                SERVICE_CODE,
+                SERVICE_EDITION
+        );
+
+        assertThat(organisasjoner).contains(
+                Organisasjon.builder()
+                        .name("JØA OG SEL")
+                        .type("Business")
+                        .parentOrganizationNumber("910020102")
+                        .organizationNumber("910098896")
+                        .organizationForm("BEDR")
+                        .status("Active")
+                        .build()
+        );
+    }
+
+
+    private void setTokenContext(String fnr) {
+        when(tokenUtils.getSelvbetjeningTokenContext()).thenReturn(
+                new TokenContext(
+                        ISSUER_SELVBETJENING,
+                        fnr +"<--FNR_i_klar_tekst_for_MockServer")
+        );
+    }
+}

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/services/altinn/AltinnServiceTest.java
@@ -3,6 +3,7 @@ package no.nav.tag.dittNavArbeidsgiver.services.altinn;
 import no.finn.unleash.Unleash;
 import no.nav.tag.dittNavArbeidsgiver.models.Organisasjon;
 import no.nav.tag.dittNavArbeidsgiver.utils.TokenUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -28,11 +29,22 @@ public class AltinnServiceTest {
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class)))
             .thenReturn(ResponseEntity.ok(asList(new Organisasjon())))
             .thenReturn(ResponseEntity.ok(emptyList()));
-        AltinnService altinnService = new AltinnService(new AltinnConfig(), restTemplate, tokenUtils, unleash);
+        AltinnService altinnService = new AltinnService(getAltinnConfigForTest(), restTemplate, tokenUtils, unleash);
         altinnService.getFromAltinn(new ParameterizedTypeReference<List<Organisasjon>>() {},"http://blabla", 1, new HttpEntity<>(null));
         verify(restTemplate, times(1)).exchange(endsWith("&$top=1&$skip=0"), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
         verify(restTemplate, times(1)).exchange(endsWith("&$top=1&$skip=1"), eq(HttpMethod.GET), any(HttpEntity.class), any(ParameterizedTypeReference.class));
         verifyNoMoreInteractions(restTemplate);
     }
 
+    @NotNull
+    private AltinnConfig getAltinnConfigForTest() {
+        AltinnConfig altinnConfig = new AltinnConfig();
+        altinnConfig.setAltinnHeader("TEST");
+        altinnConfig.setAltinnurl("localhost/altinn");
+        altinnConfig.setAPIGwHeader("API_GW_Test");
+        altinnConfig.setProxyUrl("localhost/altinn-rettigheter-proxy");
+        altinnConfig.setProxyFallbackUrl("localhost/altinn");
+
+        return altinnConfig;
+    }
 }


### PR DESCRIPTION
…r Reportees
Lagt til noen endringer i AltinnService for å kunne ta i bruk `altinn-rettigheter-proxy-klient` lib. Klient biblioteket støtter foreløpig bare kall til `/reportees` uten paginering (logikken for det ligger fortsatt i AltinnService)
Lagt til ny `proxyFallbackUrl` som gjør det mulig for klient bibliotek å kalle direkte Altinn i tilfelle proxy ikke svarer.