### PR TITLE
Oppdaterer proxy-klient til en versjon som fikser Error logg ved fall…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <oidc-support.version>0.2.18</oidc-support.version>
-        <altinn-rettigheter-proxy-klient.version>0.1.1</altinn-rettigheter-proxy-klient.version>
+        <altinn-rettigheter-proxy-klient.version>0.1.3</altinn-rettigheter-proxy-klient.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
…back kall til Altinn
Versjon 0.1.3 av `altinn-rettigheter-proxy-klient` fikser _fallback_ funksjonen ved å unngå encoding av `$filter` parameter verdi ved direkte kall til Altinn.
Når kallet til altinn-proxy feilet(1) gjorde _fallback_ funksjonen et kall direkte til Altinn med samme parametre. Problemet var at Http klient (Fuel) som `altinn-rettigheter-proxy-klient` bruker encodet hele url-en med parametre slikk at `+` tegn i `Type+ne+'Person'+and+Status+eq+'Active'` ble encoded til `%3B` noe Altinn ikke tåler.
Løsning var da å erstatte `+` med _white space_ som selv blir encoded som `%20`, som Altinn kan ta imot.    
(1) Kall til Altinn feiler noen få ganger i API-Gateway med kode 502 av ukjente årsaker 