### PR TITLE
TAG-1329 Opprett og se søknader om tilgang i Altinn

### DIFF
--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -30,6 +30,8 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: preprod
+    - name: JAVA_OPTS
+      value: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
   prometheus:
     enabled: true
     path: /ditt-nav-arbeidsgiver-api/internal/actuator/prometheus

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnTilgangssøknadClient.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnTilgangssøknadClient.java
@@ -1,0 +1,138 @@
+package no.nav.tag.dittNavArbeidsgiver.clients.altinn;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.tag.dittNavArbeidsgiver.clients.altinn.dto.DelegationRequest;
+import no.nav.tag.dittNavArbeidsgiver.clients.altinn.dto.Søknadsstatus;
+import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknad;
+import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknadsskjema;
+import no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class AltinnTilgangssøknadClient {
+    private final RestTemplate restTemplate;
+    private final HttpHeaders altinnHeaders;
+    private final UriComponentsBuilder altinnUriBuilder;
+    private final URI altinnUri;
+    private final ParameterizedTypeReference<Søknadsstatus> søknadsstatusType;
+    private final ParameterizedTypeReference<DelegationRequest> delegationRequestType;
+
+    @Autowired
+    public AltinnTilgangssøknadClient(RestTemplate restTemplate, AltinnConfig altinnConfig) {
+        this.restTemplate = restTemplate;
+
+        this.altinnUriBuilder = UriComponentsBuilder.fromUriString(
+                altinnConfig.getProxyFallbackUrl()
+                        + "/ekstern/altinn/api/serviceowner/delegationRequests?ForceEIAuthentication"
+        );
+
+
+        this.altinnUri = altinnUriBuilder.build().toUri();
+        log.info("altinnUri: {}", altinnUri.toString());
+
+        this.altinnHeaders = new HttpHeaders();
+        this.altinnHeaders.add("accept", "application/hal+json");
+        this.altinnHeaders.add("apikey", altinnConfig.getAltinnHeader());
+        this.altinnHeaders.add("x-nav-apikey", altinnConfig.getAPIGwHeader());
+
+        this.søknadsstatusType = new ParameterizedTypeReference<>() {
+        };
+
+        this.delegationRequestType = new ParameterizedTypeReference<>() {
+        };
+    }
+
+
+    public List<AltinnTilgangssøknad> hentSøknader(String fødselsnummer, String orgnr) {
+        var resultat = new ArrayList<AltinnTilgangssøknad>();
+        URI uri = altinnUri;
+
+        do {
+            var request = RequestEntity.get(uri).headers(altinnHeaders).build();
+            var response = restTemplate.exchange(request, søknadsstatusType);
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                var msg = String.format("Henting av status på tilgangssøknader feilet med http-status %s", response.getStatusCode());
+                log.error(msg);
+                throw new RuntimeException(msg);
+            }
+
+            var body = response.getBody();
+            if (body.embedded.delegationRequests.isEmpty()) {
+                uri = null;
+            } else {
+                uri = altinnUriBuilder
+                        .cloneBuilder()
+                        .queryParam("continuation", body.continuationtoken)
+                        .build()
+                        .toUri();
+            }
+
+            body.embedded
+                    .delegationRequests
+                    .stream()
+                    .filter(søknad ->
+                            fødselsnummer.equals(søknad.CoveredBy)
+                                    && orgnr.equals(søknad.OfferedBy)
+                    )
+                    .map(søknadDTO -> {
+                        var søknad = new AltinnTilgangssøknad();
+                        søknad.setStatus(søknadDTO.RequestStatus);
+                        søknad.setCratedDateTime(søknadDTO.Created);
+                        søknad.setLastChangedDateTime(søknadDTO.LastChanged);
+                        søknad.setServiceCode(søknadDTO.RequestResources.get(0).ServiceCode);
+                        søknad.setServiceEdition(søknadDTO.RequestResources.get(0).ServiceEditionCode);
+                        søknad.setSubmitUrl(søknadDTO.links.sendRequest.href);
+                        return søknad;
+                    })
+                    .collect(Collectors.toCollection(() -> resultat));
+        } while (uri != null);
+
+        return resultat;
+    }
+
+    public AltinnTilgangssøknad sendSøknad(String fødselsnummer, AltinnTilgangssøknadsskjema søknadsskjema) {
+        var requestResource = new DelegationRequest.RequestResource();
+        requestResource.ServiceCode = søknadsskjema.serviceCode;
+        requestResource.ServiceEditionCode = søknadsskjema.serviceEdition;
+
+        var delegationRequest = new DelegationRequest();
+        delegationRequest.CoveredBy = fødselsnummer;
+        delegationRequest.OfferedBy = søknadsskjema.orgnr;
+        delegationRequest.RedirectUrl = søknadsskjema.redirectUrl;
+        delegationRequest.RequestResources = List.of(requestResource);
+
+        var request = RequestEntity
+                .post(altinnUri)
+                .headers(altinnHeaders)
+                .body(delegationRequest);
+
+        var response = restTemplate.exchange(request, delegationRequestType);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            var msg = String.format("Ny tilgangssøknad i altinn feilet med http-status %s", response.getStatusCode());
+            log.error(msg);
+            throw new RuntimeException(msg);
+        }
+
+        var body = response.getBody();
+
+        var svar = new AltinnTilgangssøknad();
+        svar.setStatus(body.RequestStatus);
+        svar.setSubmitUrl(body.links.sendRequest.href);
+        return svar;
+    }
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnTilgangssøknadClient.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnTilgangssøknadClient.java
@@ -56,7 +56,7 @@ public class AltinnTilgangssøknadClient {
     }
 
 
-    public List<AltinnTilgangssøknad> hentSøknader(String fødselsnummer, String orgnr) {
+    public List<AltinnTilgangssøknad> hentSøknader(String fødselsnummer) {
         var resultat = new ArrayList<AltinnTilgangssøknad>();
         URI uri = altinnUri;
 
@@ -84,10 +84,7 @@ public class AltinnTilgangssøknadClient {
             body.embedded
                     .delegationRequests
                     .stream()
-                    .filter(søknad ->
-                            fødselsnummer.equals(søknad.CoveredBy)
-                                    && orgnr.equals(søknad.OfferedBy)
-                    )
+                    .filter(søknad -> fødselsnummer.equals(søknad.CoveredBy))
                     .map(søknadDTO -> {
                         var søknad = new AltinnTilgangssøknad();
                         søknad.setStatus(søknadDTO.RequestStatus);

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/dto/DelegationRequest.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/dto/DelegationRequest.java
@@ -1,0 +1,42 @@
+package no.nav.tag.dittNavArbeidsgiver.clients.altinn.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DelegationRequest {
+    public String RequestStatus;
+    public String OfferedBy;
+    public String CoveredBy;
+    public String RedirectUrl;
+    public String Created;
+    public String LastChanged;
+
+    public List<RequestResource> RequestResources;
+
+    @JsonProperty("_links")
+    public Links links;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RequestResource {
+        public String ServiceCode;
+        public Integer ServiceEditionCode;
+    }
+
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Links {
+        public Link sendRequest;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Link {
+        public String href;
+    }
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/dto/Søknadsstatus.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/dto/Søknadsstatus.java
@@ -1,0 +1,19 @@
+package no.nav.tag.dittNavArbeidsgiver.clients.altinn.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Søknadsstatus {
+    @JsonProperty("_embedded")
+    public Embedded embedded;
+
+    public String continuationtoken;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Embedded {
+        public List<DelegationRequest> delegationRequests;
+    }
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
@@ -1,44 +1,83 @@
 package no.nav.tag.dittNavArbeidsgiver.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.common.utils.Pair;
 import no.nav.security.token.support.core.api.Protected;
 import no.nav.security.token.support.core.context.TokenValidationContextHolder;
 import no.nav.tag.dittNavArbeidsgiver.clients.altinn.AltinnTilgangssøknadClient;
 import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknad;
 import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknadsskjema;
+import no.nav.tag.dittNavArbeidsgiver.services.altinn.AltinnService;
 import no.nav.tag.dittNavArbeidsgiver.utils.FnrExtractor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Protected
 @Slf4j
 @RestController
-@RequestMapping("/api/altinnTilgangssoeknad")
+@RequestMapping("/api/altinn-tilgangssoknad")
 public class AltinnTilgangController {
-    private final AltinnTilgangssøknadClient altinnClient;
+    private static final Set<Pair<String, String>> våreTjenester = Set.of(
+            Pair.of("5216",  "1"),
+            Pair.of("5212",  "1"),
+            Pair.of("5384",  "1"),
+            Pair.of("5159", "1"),
+            Pair.of("4936",  "1"),
+            Pair.of("5332", "2"),
+            Pair.of("5332", "1"),
+            Pair.of("5441",  "1"),
+            Pair.of("5516", "1"),
+            Pair.of("5516", "2"),
+            Pair.of("3403", "2"),
+            Pair.of("5078",  "1")
+    );
+
+    private final AltinnTilgangssøknadClient altinnTilgangssøknadClient;
+    private final AltinnService altinnService;
     private final TokenValidationContextHolder requestContextHolder;
 
     @Autowired
     public AltinnTilgangController(
-            AltinnTilgangssøknadClient altinnClient,
+            AltinnTilgangssøknadClient altinnTilgangssøknadClient,
+            AltinnService altinnService,
             TokenValidationContextHolder requestContextHolder
     ) {
-        this.altinnClient = altinnClient;
+        this.altinnTilgangssøknadClient = altinnTilgangssøknadClient;
+        this.altinnService = altinnService;
         this.requestContextHolder = requestContextHolder;
     }
 
     @GetMapping()
     public ResponseEntity<List<AltinnTilgangssøknad>> mineSøknaderOmTilgang() {
         String fødselsnummer = FnrExtractor.extract(requestContextHolder);
-        return ResponseEntity.ok(altinnClient.hentSøknader(fødselsnummer));
+        return ResponseEntity.ok(altinnTilgangssøknadClient.hentSøknader(fødselsnummer));
     }
 
     @PostMapping()
     public ResponseEntity<AltinnTilgangssøknad> sendSøknadOmTilgang(@RequestBody AltinnTilgangssøknadsskjema søknadsskjema) {
         var fødselsnummer= FnrExtractor.extract(requestContextHolder);
-        return ResponseEntity.ok(altinnClient.sendSøknad(fødselsnummer, søknadsskjema));
+
+        var brukerErIOrg = altinnService.hentOrganisasjoner(fødselsnummer)
+                .stream()
+                .anyMatch(org -> org.getOrganizationNumber().equals(søknadsskjema.orgnr));
+
+        if (!brukerErIOrg) {
+            log.warn("Bruker forsøker å be om tilgang til org de ikke er med i.");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        Pair<String, String> tjeneste = Pair.of(søknadsskjema.serviceCode, søknadsskjema.serviceEdition.toString());
+
+        if (!våreTjenester.contains(tjeneste)) {
+            log.warn("Bruker forsøker å be om tilgang til tjeneste ({}, {})) vi ikke støtter.", søknadsskjema.serviceCode, søknadsskjema.serviceEdition);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        return ResponseEntity.ok(altinnTilgangssøknadClient.sendSøknad(fødselsnummer, søknadsskjema));
     }
 }

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
@@ -8,12 +8,10 @@ import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknad;
 import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknadsskjema;
 import no.nav.tag.dittNavArbeidsgiver.utils.FnrExtractor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 @Protected
 @Slf4j
@@ -22,7 +20,6 @@ import java.util.regex.Pattern;
 public class AltinnTilgangController {
     private final AltinnTilgangssøknadClient altinnClient;
     private final TokenValidationContextHolder requestContextHolder;
-    private final Pattern orgnrPattern = Pattern.compile("[0-9]+");
 
     @Autowired
     public AltinnTilgangController(
@@ -34,14 +31,9 @@ public class AltinnTilgangController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<AltinnTilgangssøknad>> mineSøknaderOmTilgang(@RequestParam String orgnr) {
-        if (!orgnrPattern.matcher(orgnr).matches()) {
-            log.warn("GET /api/altinnTilgangssoeknad: ugyldig orgnr");
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
+    public ResponseEntity<List<AltinnTilgangssøknad>> mineSøknaderOmTilgang() {
         String fødselsnummer = FnrExtractor.extract(requestContextHolder);
-        return ResponseEntity.ok(altinnClient.hentSøknader(fødselsnummer, orgnr));
+        return ResponseEntity.ok(altinnClient.hentSøknader(fødselsnummer));
     }
 
     @PostMapping()

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/controller/AltinnTilgangController.java
@@ -1,0 +1,52 @@
+package no.nav.tag.dittNavArbeidsgiver.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.security.token.support.core.api.Protected;
+import no.nav.security.token.support.core.context.TokenValidationContextHolder;
+import no.nav.tag.dittNavArbeidsgiver.clients.altinn.AltinnTilgangssøknadClient;
+import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknad;
+import no.nav.tag.dittNavArbeidsgiver.models.AltinnTilgangssøknadsskjema;
+import no.nav.tag.dittNavArbeidsgiver.utils.FnrExtractor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Protected
+@Slf4j
+@RestController
+@RequestMapping("/api/altinnTilgangssoeknad")
+public class AltinnTilgangController {
+    private final AltinnTilgangssøknadClient altinnClient;
+    private final TokenValidationContextHolder requestContextHolder;
+    private final Pattern orgnrPattern = Pattern.compile("[0-9]+");
+
+    @Autowired
+    public AltinnTilgangController(
+            AltinnTilgangssøknadClient altinnClient,
+            TokenValidationContextHolder requestContextHolder
+    ) {
+        this.altinnClient = altinnClient;
+        this.requestContextHolder = requestContextHolder;
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<AltinnTilgangssøknad>> mineSøknaderOmTilgang(@RequestParam String orgnr) {
+        if (!orgnrPattern.matcher(orgnr).matches()) {
+            log.warn("GET /api/altinnTilgangssoeknad: ugyldig orgnr");
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        String fødselsnummer = FnrExtractor.extract(requestContextHolder);
+        return ResponseEntity.ok(altinnClient.hentSøknader(fødselsnummer, orgnr));
+    }
+
+    @PostMapping()
+    public ResponseEntity<AltinnTilgangssøknad> sendSøknadOmTilgang(@RequestBody AltinnTilgangssøknadsskjema søknadsskjema) {
+        var fødselsnummer= FnrExtractor.extract(requestContextHolder);
+        return ResponseEntity.ok(altinnClient.sendSøknad(fødselsnummer, søknadsskjema));
+    }
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/AltinnTilgangssøknad.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/AltinnTilgangssøknad.java
@@ -1,0 +1,18 @@
+package no.nav.tag.dittNavArbeidsgiver.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AltinnTilgangssøknad {
+    String orgnr;
+    String serviceCode;
+    Integer serviceEdition;
+    String status;
+    String cratedDateTime;
+    String lastChangedDateTime;
+    String submitUrl;
+}

--- a/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/AltinnTilgangssøknadsskjema.java
+++ b/src/main/java/no/nav/tag/dittNavArbeidsgiver/models/AltinnTilgangssøknadsskjema.java
@@ -1,0 +1,8 @@
+package no.nav.tag.dittNavArbeidsgiver.models;
+
+public class AltinnTilgangssøknadsskjema {
+    public String orgnr;
+    public String redirectUrl;
+    public String serviceCode;
+    public Integer serviceEdition;
+}

--- a/src/test/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnDelegationRequestsDeserializeTest.java
+++ b/src/test/java/no/nav/tag/dittNavArbeidsgiver/clients/altinn/AltinnDelegationRequestsDeserializeTest.java
@@ -1,0 +1,22 @@
+package no.nav.tag.dittNavArbeidsgiver.clients.altinn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import no.nav.tag.dittNavArbeidsgiver.clients.altinn.dto.Søknadsstatus;
+import org.junit.Test;
+
+import java.util.List;
+
+public class AltinnDelegationRequestsDeserializeTest {
+
+
+    @Test
+    public void deserialiseJsonResponseIntoDTO() throws Exception {
+        var text = this.getClass().getResourceAsStream("/altinnTilgangerGet.json").readAllBytes();
+        var mapper = new JsonMapper();
+        var json = mapper.readValue(text, new TypeReference<Søknadsstatus>() {
+        });
+
+        /* no parse error */
+    }
+}

--- a/src/test/resources/altinnTilgangerGet.json
+++ b/src/test/resources/altinnTilgangerGet.json
@@ -1,0 +1,371 @@
+{
+"_links": {
+"next": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests?continuation=2020-09-14T13:30:49.737_8724"
+},
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests"
+}
+},
+"_embedded": {
+"delegationRequests": [
+{
+"Guid": "1a9e3a32-252b-4d81-a23c-ed0d86b852c7",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"RequestMessage": "Trenger dette for aa soeke om sykemeldinger",
+"Created": "2020-08-27T08:51:31.54",
+"LastChanged": "2020-08-27T08:51:31.54",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/1a9e3a32-252b-4d81-a23c-ed0d86b852c7"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/1a9e3a32-252b-4d81-a23c-ed0d86b852c7"
+}
+}
+},
+{
+"Guid": "da5a3c76-7500-4eb8-9649-22102ef4f706",
+"RequestStatus": "Unopened",
+"CoveredBy": "16120101181",
+"OfferedBy": "910712268",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-27T18:45:58.707",
+"LastChanged": "2020-08-27T18:46:57.3",
+"RequestResources": [
+{
+"ServiceCode": "5384",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/da5a3c76-7500-4eb8-9649-22102ef4f706"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/da5a3c76-7500-4eb8-9649-22102ef4f706"
+}
+}
+},
+{
+"Guid": "137be1f5-587b-453a-8073-41b4c1438584",
+"RequestStatus": "Unopened",
+"CoveredBy": "16120101181",
+"OfferedBy": "910712268",
+"RedirectUrl": "http://localhost/test?bedrift=12345",
+"Created": "2020-08-28T08:41:22.633",
+"LastChanged": "2020-08-28T08:42:18.93",
+"RequestResources": [
+{
+"ServiceCode": "5216",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/137be1f5-587b-453a-8073-41b4c1438584"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/137be1f5-587b-453a-8073-41b4c1438584"
+}
+}
+},
+{
+"Guid": "f62d0d02-d84e-400a-83ef-63de62397f64",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"RequestMessage": "Trenger dette for aa soeke om sykemeldinger",
+"Created": "2020-08-28T14:00:07.027",
+"LastChanged": "2020-08-28T14:00:07.027",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/f62d0d02-d84e-400a-83ef-63de62397f64"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/f62d0d02-d84e-400a-83ef-63de62397f64"
+}
+}
+},
+{
+"Guid": "95ac20a2-e825-4528-acc9-1c8b2249db3a",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"RequestMessage": "Trenger dette for aa soeke om sykemeldinger",
+"Created": "2020-08-28T14:00:12.307",
+"LastChanged": "2020-08-28T14:00:12.307",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/95ac20a2-e825-4528-acc9-1c8b2249db3a"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/95ac20a2-e825-4528-acc9-1c8b2249db3a"
+}
+}
+},
+{
+"Guid": "85bc5b4d-04a7-44cb-b771-1464c0383c2c",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"RequestMessage": "Trenger dette for aa soeke om sykemeldinger",
+"Created": "2020-08-28T14:00:26.93",
+"LastChanged": "2020-08-28T14:00:26.93",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/85bc5b4d-04a7-44cb-b771-1464c0383c2c"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/85bc5b4d-04a7-44cb-b771-1464c0383c2c"
+}
+}
+},
+{
+"Guid": "07f8aaa4-8724-439d-83ee-e2cf71eca266",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:00:49.48",
+"LastChanged": "2020-08-28T14:00:49.48",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/07f8aaa4-8724-439d-83ee-e2cf71eca266"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/07f8aaa4-8724-439d-83ee-e2cf71eca266"
+}
+}
+},
+{
+"Guid": "bbeb3ad4-b53d-471b-b21d-f1565325022f",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:00:50.637",
+"LastChanged": "2020-08-28T14:00:50.637",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/bbeb3ad4-b53d-471b-b21d-f1565325022f"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/bbeb3ad4-b53d-471b-b21d-f1565325022f"
+}
+}
+},
+{
+"Guid": "d78fb740-bc70-4ce7-9732-a46268e10f60",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:01:44.86",
+"LastChanged": "2020-08-28T14:01:44.86",
+"RequestResources": [
+{
+"ServiceCode": "5384",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/d78fb740-bc70-4ce7-9732-a46268e10f60"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/d78fb740-bc70-4ce7-9732-a46268e10f60"
+}
+}
+},
+{
+"Guid": "821e2364-6d70-4b20-ad8d-8175bf6c2b8d",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:01:46.02",
+"LastChanged": "2020-08-28T14:01:46.02",
+"RequestResources": [
+{
+"ServiceCode": "5384",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/821e2364-6d70-4b20-ad8d-8175bf6c2b8d"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/821e2364-6d70-4b20-ad8d-8175bf6c2b8d"
+}
+}
+},
+{
+"Guid": "a676e3d8-6a38-436a-88d1-d4618b97af6d",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:15:15.45",
+"LastChanged": "2020-08-28T14:15:15.45",
+"RequestResources": [
+{
+"ServiceCode": "5384",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/a676e3d8-6a38-436a-88d1-d4618b97af6d"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/a676e3d8-6a38-436a-88d1-d4618b97af6d"
+}
+}
+},
+{
+"Guid": "717a468a-8aea-41d6-844a-6a122e1a3843",
+"RequestStatus": "Unopened",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"Created": "2020-08-28T14:15:21.71",
+"LastChanged": "2020-08-28T14:16:32.133",
+"RequestResources": [
+{
+"ServiceCode": "5384",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/717a468a-8aea-41d6-844a-6a122e1a3843"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/717a468a-8aea-41d6-844a-6a122e1a3843"
+}
+}
+},
+{
+"Guid": "813a7f52-69b5-41c4-a44b-5aacb1b18a4c",
+"RequestStatus": "Created",
+"CoveredBy": "16120101181",
+"OfferedBy": "910825526",
+"RedirectUrl": "http://localhost",
+"RequestMessage": "Trenger dette for aa soeke om sykemeldinger",
+"Created": "2020-09-14T13:30:49.737",
+"LastChanged": "2020-09-14T13:30:49.737",
+"RequestResources": [
+{
+"ServiceCode": "4751",
+"ServiceEditionCode": 1,
+"Operations": [
+"Read",
+"Write"
+]
+}
+],
+"_links": {
+"self": {
+"href": "https://tt02.altinn.no/api/serviceowner/delegationrequests/813a7f52-69b5-41c4-a44b-5aacb1b18a4c"
+},
+"sendRequest": {
+"href": "https://tt02.altinn.no/ui/DelegationRequest/send/813a7f52-69b5-41c4-a44b-5aacb1b18a4c"
+}
+}
+}
+]
+},
+"continuationtoken": "2020-09-14T13:30:49.737_8724"
+}


### PR DESCRIPTION
Har testet å gjøre kall fra nettleseren, og det ser ut til å funke. Tenker å få dette inn, så man kan begynne så smått med frontenden.

Noen ting som vi kanskje burde bestemme oss for er:

- om vi ønsker en liste over godkjente servicecode/serviceedition som vi skal støtte (slik at en teknisk bruker ikke kan søke om hva som helst ved å kjøre manuelle rest-kall)
- om vi skal sjekke at bruker allerede har en eller annen form for rettighet i organisasjonen (igjen, slik at en teknisk bruker kan gjøre rest-kall med andre orgnr)
