### PR TITLE
Bruk altinn-rettigheter-proxy fra gcp

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Github action
+name: Test, bygg, deploy
 on:
   push:
   workflow_dispatch:
@@ -28,7 +28,8 @@ jobs:
   bygg:
     name: Bygg
     needs: test
-    if: needs.test.result == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/deploy-gcp')
+    ### VALG AV DEV-BRANCH SETTES HER:
+    if: needs.test.result == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/altinn-proxy-gcp')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,7 +122,7 @@ no.nav.security.jwt.issuer.selvbetjening:
 altinn:
   altinnHeader: ${ALTINN_HEADER}
   APIGwHeader: ${APIGW_HEADER}
-  proxyUrl: https://altinn-rettigheter-proxy/altinn-rettigheter-proxy
+  proxyUrl: https://arbeidsgiver.dev.nav.no/altinn-rettigheter-proxy/
   proxyFallbackUrl: https://api-gw-q1.oera.no
 
 
@@ -163,7 +163,7 @@ no.nav.security.jwt.issuer.selvbetjening:
 altinn:
   altinnHeader: ${ALTINN_HEADER}
   APIGwHeader: ${APIGW_HEADER}
-  proxyUrl: https://arbeidsgiver.nais.preprod.local/altinn-rettigheter-proxy
+  proxyUrl: https://arbeidsgiver.dev.intern.nav.no/altinn-rettigheter-proxy/
   proxyFallbackUrl: https://api-gw-q1.adeo.no
 
 
@@ -205,7 +205,7 @@ no.nav.security.jwt.issuer.selvbetjening:
 altinn:
   altinnHeader: ${ALTINN_HEADER}
   APIGwHeader: ${APIGW_HEADER}
-  proxyUrl: https://arbeidsgiver.nais.adeo.no/altinn-rettigheter-proxy
+  proxyUrl: https://arbeidsgiver.intern.nav.no/altinn-rettigheter-proxy/
   proxyFallbackUrl: https://api-gw.adeo.no
 
 unleash:


### PR DESCRIPTION
Testet i dev med deployment.

Testet manuelt i prod med wget at kallet funker.

Lav risiko for nedetide, siden altinn-rettigheter-proxy-klient kaller altinn direkte hvis proxy-en feiler.