### PR TITLE
TAG-1569: legg til bedrifsnummer som fungerer mot tiltaksløsningen

### DIFF
--- a/src/main/resources/mock/organisasjoner.json
+++ b/src/main/resources/mock/organisasjoner.json
@@ -176,5 +176,20 @@
     "ParentOrganizationNumber": "910820834",
     "OrganizationForm": "BEDR",
     "Status": "Active"
+  },
+  {
+    "Name": "BIRTAVARRE OG VÆRLANDET FORELDER",
+    "Type": "Enterprise",
+    "OrganizationNumber": "910825555",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "SALTRØD OG HØNEBY",
+    "Type": "Business",
+    "OrganizationNumber": "999999999",
+    "ParentOrganizationNumber": "910825555",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
   }
 ]

--- a/src/main/resources/mock/rettigheterTilSkjema.json
+++ b/src/main/resources/mock/rettigheterTilSkjema.json
@@ -6,5 +6,20 @@
     "ParentOrganizationNumber": "910020102",
     "OrganizationForm": "BEDR",
     "Status": "Active"
+  },
+  {
+    "Name": "BIRTAVARRE OG VÆRLANDET FORELDER",
+    "Type": "Enterprise",
+    "OrganizationNumber": "910825555",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "SALTRØD OG HØNEBY",
+    "Type": "Business",
+    "OrganizationNumber": "999999999",
+    "ParentOrganizationNumber": "910825555",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
   }
 ]


### PR DESCRIPTION
ser ikke ut som denne benyttes på labs. deployet dit, men det hadde ikke ønsket effekt. Ser ut som bedriftsmenyen henter fra mock. Har en pr i front også på det: https://github.com/navikt/ditt-nav-arbeidsgiver/pull/495